### PR TITLE
Fix copy src in configure-apache-RedHat.yml

### DIFF
--- a/tasks/configure-apache-RedHat.yml
+++ b/tasks/configure-apache-RedHat.yml
@@ -26,7 +26,7 @@
 
 - name: Configure Apache definition for HTTPS.
   copy:
-    remote_src: "{{ apache_doc_root }}/clustercontrol/app/tools/apache2/s9s-ssl.conf"
+    src: "{{ apache_doc_root }}/clustercontrol/app/tools/apache2/s9s-ssl.conf"
     dest: "{{ apache_ssl_config }}"
     owner: root
     group: root


### PR DESCRIPTION
Hello,

This fixes the following warning:

```
[WARNING]: While constructing a mapping from $HOME/.ansible/roles/severalnines.clustercontrol/tasks/configure-apache-RedHat.yml, line 29, column 5, found a duplicate
dict key (remote_src). Using last defined value only.
```